### PR TITLE
Updated Environment Canada URL

### DIFF
--- a/MMM-EnvCanada.js
+++ b/MMM-EnvCanada.js
@@ -138,9 +138,7 @@ Module.register("MMM-EnvCanada", {
 	},
 
 	async fetchForecastFile() {
-		let forecastURL = "https://dd.weather.gc.ca/" + this.getCurrentDate() + "/";
-
-		forecastURL += "WXO-DD/citypage_weather/" + this.config.provCode;
+		let forecastURL = "https://dd.weather.gc.ca/today/citypage_weather/" + this.config.provCode;
 		const hour = this.getCurrentHourGMT();
 
 		forecastURL += `/${hour}/`;


### PR DESCRIPTION
Module stopped updating on Tuesday, was noted in [a bug in the default MM2 weather module](https://github.com/MagicMirrorOrg/MagicMirror/issues/3822) that ECCC has adjusted the url to include /today/ in the path.

Made a change to the fetchForecastFile function in MMM-EnvCanada.js and seems to work again.